### PR TITLE
Create iperl.json

### DIFF
--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/iperl.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/iperl.json
@@ -1,0 +1,89 @@
+{
+  "total_m3": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "Sensus",
+        "model": "Sensus iPERL",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "{name} total",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:gauge",
+      "unit_of_measurement": "m³",
+      "state_class": "total_increasing",
+      "device_class": "water",
+      "enabled_by_default": true
+    }
+  },
+
+  "timestamp": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "Sensus",
+        "model": "Sensus iPERL",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "{name} timestamp",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:calendar-clock",
+      "enabled_by_default": false
+    }
+  },
+
+  "rssi_dbm": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "Sensus",
+        "model": "Sensus iPERL",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "{name} rssi",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:signal",
+      "unit_of_measurement": "dbm",
+      "device_class": "signal_strength",
+      "state_class": "measurement",
+      "enabled_by_default": false
+    }
+  },
+
+  "max_flow_m3h": {
+    "component": "sensor",
+    "discovery_payload": {
+        "device": {
+            "identifiers": ["wmbusmeters_{id}"],
+            "manufacturer": "Sensus",
+            "model": "Sensus iPERL",
+            "name": "{name}",
+            "hw_version": "{id}"
+        },
+      "name": "{name} max flow",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:gauge",
+      "unit_of_measurement": "m³h",
+      "device_class": "water",
+      "enabled_by_default": true
+    }
+  }
+}


### PR DESCRIPTION
This is for Sensus Ipearl Wasser Zähler von Main Kinzig Kreiswerke water meter mqtt discovery file.

following values are availlable:

(shell) env "METER_ID=30882272"
(shell) env "METER_NAME=watermeter"
(shell) env "METER_MEDIA=water"
(shell) env "METER_TYPE=iperl"
(shell) env "METER_TIMESTAMP=2023-04-06T14:04:57Z"
(shell) env "METER_TIMESTAMP_UTC=2023-04-06T14:04:57Z"
(shell) env "METER_TIMESTAMP_UT=1680789897"
(shell) env "METER_TIMESTAMP_LT=2023-04-06 16:04.57"
(shell) env "METER_DEVICE=rtlwmbus[cmd_0]"
(shell) env "METER_RSSI_DBM=130"
(shell) env "METER_TOTAL_M3=2.367"
(shell) env "METER_MAX_FLOW_M3H=0"

My water meter is the 433 version with freq 434.475M.