### PR TITLE
Add mqtt discovery files for Engelmann HCA e2

### DIFF
--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/hcae2.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/hcae2.json
@@ -9,7 +9,7 @@
                 "manufacturer": "Engelmann",
                 "model": "HCA e2",
                 "name": "{name}",
-                "sw_version": "{id}"
+                "hw_version": "{id}"
             },
             "enabled_by_default": true,
             "json_attributes_topic": "wmbusmeters/{name}",
@@ -32,7 +32,7 @@
                 "manufacturer": "Engelmann",
                 "model": "HCA e2",
                 "name": "{name}",
-                "sw_version": "{id}"
+                "hw_version": "{id}"
             },
             "enabled_by_default": false,
             "entity_category": "diagnostic",
@@ -56,7 +56,7 @@
 			   "manufacturer": "Engelmann",
 			   "model": "HCA e2",
 			   "name": "{name}",
-			   "sw_version": "{id}"
+			   "hw_version": "{id}"
 			},
 			"entity_category": "diagnostic",
 			"name": "{name} timestamp",
@@ -76,7 +76,7 @@
                 "manufacturer": "Engelmann",
                 "model": "HCA e2",
                 "name": "{name}",
-                "sw_version": "{id}"
+                "hw_version": "{id}"
             },
             "enabled_by_default": false,
             "entity_category": "diagnostic",

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/hcae2.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/hcae2.json
@@ -1,0 +1,92 @@
+{
+    "current_consumption_hca": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Engelmann",
+                "model": "HCA e2",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "json_attributes_topic": "wmbusmeters/{name}",
+            "state_class": "total",
+            "name": "{name} heat cost total",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "hca",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:gauge"
+        }
+    },
+    "rssi_dbm": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Engelmann",
+                "model": "HCA e2",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "signal_strength",
+            "state_class": "measurement",
+            "name": "{name} rssi",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "dbm",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:signal"
+        }
+    },
+	"timestamp": {
+		"component":"sensor",
+		"discovery_payload":{
+			"device":{
+				"identifiers":[
+					"wmbusmeters_{id}"
+				],
+			   "manufacturer": "Engelmann",
+			   "model": "HCA e2",
+			   "name": "{name}",
+			   "sw_version": "{id}"
+			},
+			"entity_category": "diagnostic",
+			"name": "{name} timestamp",
+			"unique_id": "wmbusmeters_{id}_{attribute}",
+			"state_topic": "wmbusmeters/{name}",
+			"value_template": "{{ value_json.{attribute} }}",
+			"icon": "mdi:calendar-clock",
+			"device_class": "timestamp",
+			"enabled_by_default": false
+		}
+    },
+	"status_ERROR": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "Engelmann",
+                "model": "HCA e2",
+                "name": "{name}",
+                "sw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "{name} error",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'ERROR' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    }
+}


### PR DESCRIPTION
Tested with version: 1.13.1-20-1 and one HCA e2 device.
I'm not shure regarding the line **"sw_version": "{id}"**, since {id} is the serial number of the device and not the sw-version.