### PR TITLE
"dbm" changed to "dBm" in mqtt_discovery files

### DIFF
--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/amiplus.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/amiplus.json
@@ -226,7 +226,7 @@
         "state_topic":"wmbusmeters/{name}",
         "value_template":"{{ value_json.{attribute} }}",
         "icon":"mdi:signal",
-        "unit_of_measurement":"dbm",
+        "unit_of_measurement":"dBm",
         "device_class":"signal_strength",
         "state_class":"measurement",
         "enabled_by_default":true

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/apator162.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/apator162.json
@@ -62,7 +62,7 @@
       "state_topic": "wmbusmeters/{name}",
       "value_template": "{{ value_json.{attribute} }}",
       "icon": "mdi:signal",
-      "unit_of_measurement": "dbm",
+      "unit_of_measurement": "dBm",
       "device_class": "signal_strength",
       "state_class": "measurement",
       "enabled_by_default": true

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/apatoreitn.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/apatoreitn.json
@@ -174,7 +174,7 @@
       "state_topic": "wmbusmeters/{name}",
       "value_template": "{{ value_json.{attribute} }}",
       "icon": "mdi:signal",
-      "unit_of_measurement": "dbm",
+      "unit_of_measurement": "dBm",
       "device_class": "signal_strength",
       "state_class": "measurement",
       "enabled_by_default": true

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/fhkvdataiii.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/fhkvdataiii.json
@@ -103,7 +103,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/flowiq2200.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/flowiq2200.json
@@ -262,7 +262,7 @@
       "name": "{name} rssi",
       "state_topic": "wmbusmeters/{name}",
       "unique_id": "wmbusmeters_{id}_{attribute}",
-      "unit_of_measurement": "dbm",
+      "unit_of_measurement": "dBm",
       "value_template": "{{ value_json.{attribute} }}",
       "icon": "mdi:signal"
     }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/hcae2.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/hcae2.json
@@ -41,7 +41,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/iperl.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/iperl.json
@@ -58,7 +58,7 @@
       "state_topic": "wmbusmeters/{name}",
       "value_template": "{{ value_json.{attribute} }}",
       "icon": "mdi:signal",
-      "unit_of_measurement": "dbm",
+      "unit_of_measurement": "dBm",
       "device_class": "signal_strength",
       "state_class": "measurement",
       "enabled_by_default": false

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/izar.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/izar.json
@@ -101,7 +101,7 @@
       "state_topic": "wmbusmeters/{name}",
       "value_template": "{{ value_json.{attribute} }}",
       "icon": "mdi:signal",
-      "unit_of_measurement": "dbm",
+      "unit_of_measurement": "dBm",
       "device_class": "signal_strength",
       "state_class": "measurement",
       "enabled_by_default": false

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/kamheat.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/kamheat.json
@@ -414,7 +414,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/lse_07_17.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/lse_07_17.json
@@ -42,7 +42,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/mkradio3.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/mkradio3.json
@@ -63,7 +63,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/multical21.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/multical21.json
@@ -219,7 +219,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/qcaloric.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/qcaloric.json
@@ -41,7 +41,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/qwater.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/qwater.json
@@ -42,7 +42,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/sensostar.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/sensostar.json
@@ -401,7 +401,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/sharky774.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/sharky774.json
@@ -169,7 +169,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/tsd2.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/tsd2.json
@@ -56,7 +56,7 @@
             "name": "{name} rssi",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "dbm",
+            "unit_of_measurement": "dBm",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:signal"
         }


### PR DESCRIPTION
Changed to "dBm" because Home Assistant reported a warning.