### PR TITLE
Add mqtt discovery files for BMETERS rfmamb

### DIFF
--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/rfmamb.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/rfmamb.json
@@ -1,0 +1,449 @@
+{
+    "current_temperature_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "json_attributes_topic": "wmbusmeters/{name}",
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "name": "Temperature",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer"
+        }
+    },
+
+    "average_temperature_1h_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "name": "Avg Temperature 1h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer"
+        }
+    },
+
+    "maximum_temperature_1h_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "name": "Max Temperature 1h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer"
+        }
+    },
+
+    "minimum_temperature_1h_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "name": "Min Temperature 1h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer"
+        }
+    },
+
+    "average_temperature_24h_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "name": "Avg Temperature 24h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer"
+        }
+    },
+
+    "maximum_temperature_24h_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "name": "Max Temperature 24h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer"
+        }
+    },
+
+    "minimum_temperature_24h_c": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "name": "Min Temperature 24h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "°C",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:thermometer"
+        }
+    },
+
+    "current_relative_humidity_rh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "device_class": "humidity",
+            "state_class": "measurement",
+            "name": "Humidity",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "%",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:water-percent"
+        }
+    },
+
+    "average_relative_humidity_1h_rh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "device_class": "humidity",
+            "state_class": "measurement",
+            "name": "Avg Humidity 1h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "%",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:water-percent"
+        }
+    },
+
+    "maximum_relative_humidity_1h_rh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "device_class": "humidity",
+            "state_class": "measurement",
+            "name": "Max Humidity 1h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "%",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:water-percent"
+        }
+    },
+
+    "minimum_relative_humidity_1h_rh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "device_class": "humidity",
+            "state_class": "measurement",
+            "name": "Min Humidity 1h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "%",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:water-percent"
+        }
+    },
+
+    "average_relative_humidity_24h_rh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "device_class": "humidity",
+            "state_class": "measurement",
+            "name": "Avg Humidity 24h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "%",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:water-percent"
+        }
+    },
+
+    "maximum_relative_humidity_24h_rh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "device_class": "humidity",
+            "state_class": "measurement",
+            "name": "Max Humidity 24h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "%",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:water-percent"
+        }
+    },
+
+    "minimum_relative_humidity_24h_rh": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": false,
+            "device_class": "humidity",
+            "state_class": "measurement",
+            "name": "Min Humidity 24h",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "%",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:water-percent"
+        }
+    },
+
+    "status_OK": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "name": "Status OK",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'OK' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "status_ALARM": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "Status error (ALARM)",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'ALARM' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+    "status_POWER_LOW": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": ["wmbusmeters_{id}"],
+                "manufacturer": "BMETERS",
+                "model": "{driver}",
+                "name": "{name}",
+                "hw_version": "{id}"
+            },
+            "enabled_by_default": true,
+            "entity_category": "diagnostic",
+            "device_class": "battery",
+            "name": "Battery",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ 'POWER_LOW' in value_json.status }}",
+            "payload_on": "True",
+            "payload_off": "False"
+        }
+    },
+
+  "timestamp": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "BMETERS",
+        "model": "{driver}",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "Timestamp",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:calendar-clock",
+      "enabled_by_default": false
+    }
+  },
+
+  "rssi_dbm": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "BMETERS",
+        "model": "{driver}",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "rssi",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:signal",
+      "unit_of_measurement": "dBm",
+      "device_class": "signal_strength",
+      "state_class": "measurement",
+      "enabled_by_default": true
+    }
+  }
+}


### PR DESCRIPTION
Tested with Home Assistant v 2023.10.5

Screenshot after enabling all sensors.
- works also for elvaco CMa10w and CMa11w room sensors

![image](https://github.com/wmbusmeters/wmbusmeters-ha-addon/assets/66431079/76b74ebe-a54b-43d8-b555-25e6f62f6535)
