### PR TITLE
Added missing unismart.json mqtt discovery file

### DIFF
--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/unismart.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/unismart.json
@@ -7,7 +7,7 @@
         "manufacturer": "APATOR METRIX",
         "model": "at-wmbus-g-01 Lena",
         "name": "{name}",
-        "hw_version": "{id}"
+        "sw_version": "{id}"
       },
       "name": "total",
       "unique_id": "wmbusmeters_{id}_{attribute}",
@@ -30,7 +30,7 @@
         "manufacturer": "APATOR METRIX",
         "model": "at-wmbus-g-01 Lena",
         "name": "{name}",
-        "hw_version": "{id}"
+        "sw_version": "{id}"
       },
       "entity_category": "diagnostic",
       "name": "timestamp",
@@ -50,7 +50,7 @@
         "manufacturer": "APATOR METRIX",
         "model": "at-wmbus-g-01 Lena",
         "name": "{name}",
-        "hw_version": "{id}"
+        "sw_version": "{id}"
       },
       "entity_category": "diagnostic",
       "name": "rssi",

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/unismart.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/unismart.json
@@ -1,0 +1,67 @@
+{
+  "total_m3": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "APATOR METRIX",
+        "model": "at-wmbus-g-01 Lena",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "total",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:gauge",
+      "unit_of_measurement": "m³",
+      "state_class": "total_increasing",
+      "device_class": "gas",
+      "enabled_by_default": true
+    }
+  },
+
+  "timestamp": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "APATOR METRIX",
+        "model": "at-wmbus-g-01 Lena",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "timestamp",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:calendar-clock",
+      "enabled_by_default": false
+    }
+  },
+
+  "rssi_dbm": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "APATOR METRIX",
+        "model": "at-wmbus-g-01 Lena",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "rssi",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:signal",
+      "unit_of_measurement": "dBm",
+      "device_class": "signal_strength",
+      "state_class": "measurement",
+      "enabled_by_default": false
+    }
+  }
+}


### PR DESCRIPTION
Linked issues:
- https://github.com/wmbusmeters/wmbusmeters/issues/1209
- https://github.com/wmbusmeters/wmbusmeters/issues/827

I've noticed that there's no mqtt discovery file for unismart meters (popular gas meter in Poland).
Added it to my Home Assistant instance, works well 🙂

<img width="727" alt="image" src="https://github.com/wmbusmeters/wmbusmeters-ha-addon/assets/1921100/50f7ccbb-c635-4d7f-92dd-7ad4fa9e27a0">
<img width="612" alt="image" src="https://github.com/wmbusmeters/wmbusmeters-ha-addon/assets/1921100/f5ef0962-24bf-41c8-8eda-f26a00bd4d0c">


Raw JSON data:
```json
{
    "media": "gas",
    "meter": "unismart",
    "name": "gaz",
    "id": "deadbee",
    "target_m3": 3871.49,
    "total_m3": 3926.35,
    "fabrication_no": "REDACTED",
    "meter_timestamp": "2024-03-12 13:23:05",
    "other": "OTHER_FLAGS_13",
    "parameter_set": "02",
    "status": "STATUS_FLAGS_7F4",
    "supplier_info": "00",
    "target_date_time": "2024-03-01 06:00",
    "total_date_time": "2024-03-12 13:23",
    "version": "  4GGU",
    "timestamp": "2024-03-12T12:04:32Z",
    "device": "rtl433[00000001]",
    "rssi_dbm": 999
}
```