### PR TITLE
Aligned sensostar mqtt discovery to updated underlying sensostar driver

### DIFF
--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/sensostar.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/sensostar.json
@@ -167,7 +167,7 @@
             "name": "Status OK",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'OK' in value_json.current_status }}",
+            "value_template": "{{ 'OK' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -188,7 +188,7 @@
             "name": "Status error (Temperature Sensor 1 Cable Break)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_TEMP_SENSOR_1_CABLE_BREAK' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_1_CABLE_BREAK' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -209,7 +209,7 @@
             "name": "Status error (Temperature Sensor 1 Short Circuit)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_TEMP_SENSOR_1_SHORT_CIRCUIT' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_1_SHORT_CIRCUIT' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -230,7 +230,7 @@
             "name": "Status error (Temperature Sensor 2 Cable Break)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_TEMP_SENSOR_2_CABLE_BREAK' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_2_CABLE_BREAK' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -251,7 +251,7 @@
             "name": "Status error (Temperature Sensor 2 Short Circuit)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_TEMP_SENSOR_2_SHORT_CIRCUIT' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_2_SHORT_CIRCUIT' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -272,7 +272,7 @@
             "name": "Status error (Flow Management System)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_FLOW_MEASUREMENT_SYSTEM_ERROR' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_FLOW_MEASUREMENT_SYSTEM_ERROR' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -293,7 +293,7 @@
             "name": "Status error (Electronics Defective)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_ELECTRONICS_DEFECT' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_ELECTRONICS_DEFECT' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -313,7 +313,7 @@
             "name": "Status OK (instrument reset)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'OK_INSTRUMENT_RESET' in value_json.current_status }}",
+            "value_template": "{{ 'OK_INSTRUMENT_RESET' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -334,7 +334,7 @@
             "name": "Status OK (battery low)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'OK_BATTERY_LOW' in value_json.current_status }}",
+            "value_template": "{{ 'OK_BATTERY_LOW' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/sensostar.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/sensostar.json
@@ -340,26 +340,6 @@
         }
     },
 
-    "meter_timestamp": {
-        "component": "sensor",
-        "discovery_payload": {
-            "device": {
-                "identifiers": ["wmbusmeters_{id}"],
-                "manufacturer": "Engelmann",
-                "model": "{driver}",
-                "name": "{name}",
-                "hw_version": "{id}"
-            },
-            "enabled_by_default": true,
-            "name": "Meter timestamp",
-            "entity_category": "diagnostic",
-            "state_topic": "wmbusmeters/{name}",
-            "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ value_json.{attribute} }}",
-            "icon": "mdi:clock"
-        }
-    },
-
     "timestamp": {
         "component": "sensor",
         "discovery_payload": {

--- a/wmbusmeters-ha-addon/mqtt_discovery/sensostar.json
+++ b/wmbusmeters-ha-addon/mqtt_discovery/sensostar.json
@@ -167,7 +167,7 @@
             "name": "Status OK",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'OK' in value_json.current_status }}",
+            "value_template": "{{ 'OK' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -188,7 +188,7 @@
             "name": "Status error (Temperature Sensor 1 Cable Break)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_TEMP_SENSOR_1_CABLE_BREAK' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_1_CABLE_BREAK' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -209,7 +209,7 @@
             "name": "Status error (Temperature Sensor 1 Short Circuit)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_TEMP_SENSOR_1_SHORT_CIRCUIT' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_1_SHORT_CIRCUIT' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -230,7 +230,7 @@
             "name": "Status error (Temperature Sensor 2 Cable Break)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_TEMP_SENSOR_2_CABLE_BREAK' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_2_CABLE_BREAK' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -251,7 +251,7 @@
             "name": "Status error (Temperature Sensor 2 Short Circuit)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_TEMP_SENSOR_2_SHORT_CIRCUIT' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_TEMP_SENSOR_2_SHORT_CIRCUIT' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -272,7 +272,7 @@
             "name": "Status error (Flow Management System)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_FLOW_MEASUREMENT_SYSTEM_ERROR' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_FLOW_MEASUREMENT_SYSTEM_ERROR' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -293,7 +293,7 @@
             "name": "Status error (Electronics Defective)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'ERROR_ELECTRONICS_DEFECT' in value_json.current_status }}",
+            "value_template": "{{ 'ERROR_ELECTRONICS_DEFECT' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -313,7 +313,7 @@
             "name": "Status OK (instrument reset)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'OK_INSTRUMENT_RESET' in value_json.current_status }}",
+            "value_template": "{{ 'OK_INSTRUMENT_RESET' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }
@@ -334,7 +334,7 @@
             "name": "Status OK (battery low)",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ 'OK_BATTERY_LOW' in value_json.current_status }}",
+            "value_template": "{{ 'OK_BATTERY_LOW' in value_json.status }}",
             "payload_on": "True",
             "payload_off": "False"
         }

--- a/wmbusmeters-ha-addon/mqtt_discovery/sensostar.json
+++ b/wmbusmeters-ha-addon/mqtt_discovery/sensostar.json
@@ -340,26 +340,6 @@
         }
     },
 
-    "meter_timestamp": {
-        "component": "sensor",
-        "discovery_payload": {
-            "device": {
-                "identifiers": ["wmbusmeters_{id}"],
-                "manufacturer": "Engelmann",
-                "model": "{driver}",
-                "name": "{name}",
-                "sw_version": "{id}"
-            },
-            "enabled_by_default": true,
-            "name": "Meter timestamp",
-            "entity_category": "diagnostic",
-            "state_topic": "wmbusmeters/{name}",
-            "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ value_json.{attribute} }}",
-            "icon": "mdi:clock"
-        }
-    },
-
     "timestamp": {
         "component": "sensor",
         "discovery_payload": {


### PR DESCRIPTION
- Replaced current_status field with status (which is the one provided by the underlying sensostar driver)
- Removed meter_timestamp, since it's (currently) not provided by the underlying driver (and probably overhead, anyways)

Both changes will fix warning messages when new telegrams arrive and get parsed my mqtt