### PR TITLE
Tauron amiplus 3 tariff variant 2

### DIFF
--- a/wmbusmeters-ha-addon/mqtt_discovery/amiplus.json
+++ b/wmbusmeters-ha-addon/mqtt_discovery/amiplus.json
@@ -14,7 +14,7 @@
         "name":"total energy consumption",
         "unique_id":"wmbusmeters_{id}_{attribute}",
         "state_topic":"wmbusmeters/{name}",
-        "value_template":"{{ value_json.{attribute} }}",
+        "value_template":"{{ value_json.total_energy_consumption_kwh or (value_json.total_energy_consumption_tariff_1_kwh + value_json.total_energy_consumption_tariff_2_kwh + value_json.total_energy_consumption_tariff_3_kwh) }}",
         "json_attributes_topic":"wmbusmeters/{name}",
         "icon":"mdi:transmission-tower-import",
         "unit_of_measurement":"kWh",


### PR DESCRIPTION
Adds support for 3 tariff variant of AMIPLUS meter.  This version attempts to conditionally template energy consumption to correct for the variance of Amiplus meter which reports 3 separate tariffs. Competes with [ variant 1
](https://github.com/wmbusmeters/wmbusmeters-ha-addon/pull/54)
Can anyone give this a try, or advise how could I switch to this and test it on my home environment?