### PR TITLE
Fix and improve pollucomf

### DIFF
--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/pollucomf.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/pollucomf.json
@@ -1,4 +1,27 @@
 {
+    "power_kw": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Sensus",
+                "model": "{driver}",
+                "name": "{name}",
+                "serial_number": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "measurement",
+            "device_class": "power",
+            "name": "Power",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "kW",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:gauge"
+        }
+    },
     "total_kwh": {
         "component": "sensor",
         "discovery_payload": {
@@ -9,13 +32,12 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
-            "state_class": "total",
+            "state_class": "total_increasing",
             "device_class": "energy",
-            "name": "Total Energy",
+            "name": "Total energy",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "kWh",
@@ -33,16 +55,15 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
             "state_class": "measurement",
-            "device_class": "water",
+            "device_class": "volume_flow_rate",
             "name": "Flow",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "m³",
+            "unit_of_measurement": "m³/h",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:gauge"
         }
@@ -57,40 +78,15 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
-            "state_class": "total",
+            "state_class": "total_increasing",
             "device_class": "water",
-            "name": "Total Flow",
+            "name": "Total water",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "m³",
-            "value_template": "{{ value_json.{attribute} }}",
-            "icon": "mdi:gauge"
-        }
-    },
-    "power_kw": {
-        "component": "sensor",
-        "discovery_payload": {
-            "device": {
-                "identifiers": [
-                    "wmbusmeters_{id}"
-                ],
-                "manufacturer": "Sensus",
-                "model": "{driver}",
-                "name": "{name}",
-		"serial_number": "{id}"
-            },
-            "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
-            "state_class": "measurement",
-            "device_class": "power",
-            "name": "Power Consumption",
-            "state_topic": "wmbusmeters/{name}",
-            "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "kW",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:gauge"
         }
@@ -105,13 +101,12 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
             "state_class": "measurement",
             "device_class": "temperature",
-            "name": "Temperature Forward",
+            "name": "Temperature forward",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "°C",
@@ -129,18 +124,89 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
             "state_class": "measurement",
             "device_class": "temperature",
-            "name": "Temperature Return",
+            "name": "Temperature return",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "°C",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:temperature-celsius"
+        }
+    },
+    "on_time_h": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Sensus",
+                "model": "{driver}",
+                "name": "{name}",
+                "serial_number": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "state_class": "total_increasing",
+            "device_class": "duration",
+            "name": "Duration in OK state",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "h",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:heart-pulse"
+        }
+    },
+    "on_time_at_error_h": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Sensus",
+                "model": "{driver}",
+                "name": "{name}",
+                "serial_number": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "state_class": "total_increasing",
+            "device_class": "duration",
+            "name": "Duration in error state",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "h",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:heart-broken"
+        }
+    },
+    "status": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Sensus",
+                "model": "{driver}",
+                "name": "{name}",
+                "serial_number": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "Status",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ value_json.{attribute} }}",
+            "payload_on": "True",
+            "payload_off": "OK",
+            "icon": "mdi:list-status"
         }
     },
     "rssi_dbm": {
@@ -153,13 +219,13 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
             "entity_category": "diagnostic",
             "device_class": "signal_strength",
             "state_class": "measurement",
-            "name": "Signal Strength",
+            "name": "Signal strength",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "dBm",
@@ -177,14 +243,17 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
+            "json_attributes_topic": "wmbusmeters/{name}",
+            "json_attributes_template": "{{ {\"device_datetime\": value_json.meter_datetime} | tojson }}",
             "entity_category": "diagnostic",
-            "name": "Timestamp",
+            "device_class": "timestamp",
+            "name": "Telegram received",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ value_json.{attribute} }}",
+            "value_template": "{{ as_datetime(value_json.{attribute}) }}",
             "icon": "mdi:calendar-clock"
         }
     }

--- a/wmbusmeters-ha-addon/mqtt_discovery/pollucomf.json
+++ b/wmbusmeters-ha-addon/mqtt_discovery/pollucomf.json
@@ -1,4 +1,27 @@
 {
+    "power_kw": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Sensus",
+                "model": "{driver}",
+                "name": "{name}",
+                "serial_number": "{id}"
+            },
+            "enabled_by_default": true,
+            "state_class": "measurement",
+            "device_class": "power",
+            "name": "Power",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "kW",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:gauge"
+        }
+    },
     "total_kwh": {
         "component": "sensor",
         "discovery_payload": {
@@ -9,13 +32,12 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
-            "state_class": "total",
+            "state_class": "total_increasing",
             "device_class": "energy",
-            "name": "Total Energy",
+            "name": "Total energy",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "kWh",
@@ -33,16 +55,15 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
             "state_class": "measurement",
-            "device_class": "water",
+            "device_class": "volume_flow_rate",
             "name": "Flow",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "m³",
+            "unit_of_measurement": "m³/h",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:gauge"
         }
@@ -57,40 +78,15 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
-            "state_class": "total",
+            "state_class": "total_increasing",
             "device_class": "water",
-            "name": "Total Flow",
+            "name": "Total water",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "m³",
-            "value_template": "{{ value_json.{attribute} }}",
-            "icon": "mdi:gauge"
-        }
-    },
-    "power_kw": {
-        "component": "sensor",
-        "discovery_payload": {
-            "device": {
-                "identifiers": [
-                    "wmbusmeters_{id}"
-                ],
-                "manufacturer": "Sensus",
-                "model": "{driver}",
-                "name": "{name}",
-		"serial_number": "{id}"
-            },
-            "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
-            "state_class": "measurement",
-            "device_class": "power",
-            "name": "Power Consumption",
-            "state_topic": "wmbusmeters/{name}",
-            "unique_id": "wmbusmeters_{id}_{attribute}",
-            "unit_of_measurement": "kW",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:gauge"
         }
@@ -105,13 +101,12 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
             "state_class": "measurement",
             "device_class": "temperature",
-            "name": "Temperature Forward",
+            "name": "Temperature forward",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "°C",
@@ -129,18 +124,89 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
-            "json_attributes_topic": "wmbusmeters/{name}",
             "state_class": "measurement",
             "device_class": "temperature",
-            "name": "Temperature Return",
+            "name": "Temperature return",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "°C",
             "value_template": "{{ value_json.{attribute} }}",
             "icon": "mdi:temperature-celsius"
+        }
+    },
+    "on_time_h": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Sensus",
+                "model": "{driver}",
+                "name": "{name}",
+                "serial_number": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "state_class": "total_increasing",
+            "device_class": "duration",
+            "name": "Duration in OK state",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "h",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:heart-pulse"
+        }
+    },
+    "on_time_at_error_h": {
+        "component": "sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Sensus",
+                "model": "{driver}",
+                "name": "{name}",
+                "serial_number": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "state_class": "total_increasing",
+            "device_class": "duration",
+            "name": "Duration in error state",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "unit_of_measurement": "h",
+            "value_template": "{{ value_json.{attribute} }}",
+            "icon": "mdi:heart-broken"
+        }
+    },
+    "status": {
+        "component": "binary_sensor",
+        "discovery_payload": {
+            "device": {
+                "identifiers": [
+                    "wmbusmeters_{id}"
+                ],
+                "manufacturer": "Sensus",
+                "model": "{driver}",
+                "name": "{name}",
+                "serial_number": "{id}"
+            },
+            "enabled_by_default": false,
+            "entity_category": "diagnostic",
+            "device_class": "problem",
+            "name": "Status",
+            "state_topic": "wmbusmeters/{name}",
+            "unique_id": "wmbusmeters_{id}_{attribute}",
+            "value_template": "{{ value_json.{attribute} }}",
+            "payload_on": "True",
+            "payload_off": "OK",
+            "icon": "mdi:list-status"
         }
     },
     "rssi_dbm": {
@@ -153,13 +219,13 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
             "entity_category": "diagnostic",
             "device_class": "signal_strength",
             "state_class": "measurement",
-            "name": "Signal Strength",
+            "name": "Signal strength",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
             "unit_of_measurement": "dBm",
@@ -177,14 +243,17 @@
                 "manufacturer": "Sensus",
                 "model": "{driver}",
                 "name": "{name}",
-		"serial_number": "{id}"
+                "serial_number": "{id}"
             },
             "enabled_by_default": true,
+            "json_attributes_topic": "wmbusmeters/{name}",
+            "json_attributes_template": "{{ {\"device_datetime\": value_json.meter_datetime} | tojson }}",
             "entity_category": "diagnostic",
-            "name": "Timestamp",
+            "device_class": "timestamp",
+            "name": "Telegram received",
             "state_topic": "wmbusmeters/{name}",
             "unique_id": "wmbusmeters_{id}_{attribute}",
-            "value_template": "{{ value_json.{attribute} }}",
+            "value_template": "{{ as_datetime(value_json.{attribute}) }}",
             "icon": "mdi:calendar-clock"
         }
     }


### PR DESCRIPTION
I have an Sensus PolluCom F with the wMBus module. Via the display, the meter shows it is on Firmware 05.43. This integration and the autodiscovery work quite well, thanks for the awesome work! I made the following changes:

* Comply with https://developers.home-assistant.io/docs/core/entity/sensor/
* Comply with https://developers.home-assistant.io/blog/2022/07/10/entity_naming/
* Do not duplicate attributes on each entity_id using `json_attributes_topic`. This would duplicate the values when using the [InfluxDB integration](https://www.home-assistant.io/integrations/influxdb).
* Write `meter_datetime` as `device_datetime` attribute in "Telegram received" entity. I deviated from the rule not to add attributes because this is basically metadata that I am not sure how useful it is yet. Having it in the same entity ID as timestamp would simplify time drift analysis of meters. If one ever is interested in that. Not sure. The meter manual states that `meter_datetime` does not observe daylight savings time (DST) so I was not able to parse that because I could not come up with an easy way to determine the timezone.
* Fix units
* Sort the JSON keys in a (for me) logical order
* Add "Duration in OK state" sensor
* Add "Duration in error state" sensor
* Add "Status" binary_sensor
* Parse "timestamp" as datetime

I am aware of https://github.com/wmbusmeters/wmbusmeters/pull/927. Nice work. I am aware that some of the fixes should be done there. But I currently don’t have the time to get into that. I already spend too much time integrating the meter into Home Assistant ;-)

Cc: @frennkie