### PR TITLE
Add json for driver=topaseskr

### DIFF
--- a/wmbusmeters-ha-addon/mqtt_discovery/topaseskr.json
+++ b/wmbusmeters-ha-addon/mqtt_discovery/topaseskr.json
@@ -1,0 +1,140 @@
+{
+	"total_m3": {
+		"component": "sensor",
+		"discovery_payload": {
+			"device": {
+				"identifiers": [
+					"wmbusmeters_{id}"
+				],
+				"manufacturer": "INTEGRA METERING",
+				"model": "{driver}",
+				"name": "{name}",
+				"hw_version": "{id}"
+			},
+			"enabled_by_default": true,
+			"json_attributes_topic": "wmbusmeters/{name}",
+			"state_class": "total",
+			"device_class": "water",
+			"name": "total m3",
+			"state_topic": "wmbusmeters/{name}",
+			"unique_id": "wmbusmeters_{id}_{attribute}",
+			"unit_of_measurement": "m³",
+			"value_template": "{{ value_json.{attribute} }}",
+			"icon": "mdi:gauge"
+		}
+	},
+	"volume_month_period_m3": {
+		"component": "sensor",
+		"discovery_payload": {
+			"device": {
+				"identifiers": [
+					"wmbusmeters_{id}"
+				],
+				"manufacturer": "INTEGRA METERING",
+				"model": "{driver}",
+				"name": "{name}",
+				"hw_version": "{id}"
+			},
+			"enabled_by_default": true,
+			"json_attributes_topic": "wmbusmeters/{name}",
+			"state_class": "total",
+			"device_class": "water",
+			"name": "total month m3",
+			"state_topic": "wmbusmeters/{name}",
+			"unique_id": "wmbusmeters_{id}_{attribute}",
+			"unit_of_measurement": "m³",
+			"value_template": "{{ value_json.{attribute} }}",
+			"icon": "mdi:gauge"
+		}
+	},	
+	"volume_year_period_m3": {
+		"component": "sensor",
+		"discovery_payload": {
+			"device": {
+				"identifiers": [
+					"wmbusmeters_{id}"
+				],
+				"manufacturer": "INTEGRA METERING",
+				"model": "{driver}",
+				"name": "{name}",
+				"hw_version": "{id}"
+			},
+			"enabled_by_default": true,
+			"json_attributes_topic": "wmbusmeters/{name}",
+			"state_class": "total",
+			"device_class": "water",
+			"name": "total year m3",
+			"state_topic": "wmbusmeters/{name}",
+			"unique_id": "wmbusmeters_{id}_{attribute}",
+			"unit_of_measurement": "m³",
+			"value_template": "{{ value_json.{attribute} }}",
+			"icon": "mdi:gauge"
+		}
+	},		
+	"current_flow_m3h": {
+		"component": "sensor",
+		"discovery_payload": {
+			"device": {
+				"identifiers": [
+					"wmbusmeters_{id}"
+				],
+				"manufacturer": "INTEGRA METERING",
+				"model": "{driver}",
+				"name": "{name}",
+				"hw_version": "{id}"
+			},
+			"enabled_by_default": true,
+			"state_class": "measurement",
+			"name": "flow",
+			"state_topic": "wmbusmeters/{name}",
+			"unique_id": "wmbusmeters_{id}_{attribute}",
+			"unit_of_measurement": "m³/h",
+			"value_template": "{{ value_json.{attribute} }}",
+			"icon": "mdi:waves-arrow-right"
+		}
+	},
+	"temperature_c": {
+		"component": "sensor",
+		"discovery_payload": {
+			"device": {
+				"identifiers": [
+					"wmbusmeters_{id}"
+				],
+				"manufacturer": "INTEGRA METERING",
+				"model": "{driver}",
+				"name": "{name}",
+				"hw_version": "{id}"
+			},
+			"enabled_by_default": false,
+			"state_class": "measurement",
+			"device_class": "temperature",
+			"name": "water temperature",
+			"state_topic": "wmbusmeters/{name}",
+			"unique_id": "wmbusmeters_{id}_{attribute}",
+			"unit_of_measurement": "°C",
+			"value_template": "{{ value_json.{attribute} }}",
+			"icon": "mdi:thermometer-water"
+		}
+	},
+	"timestamp": {
+		"component": "sensor",
+		"discovery_payload": {
+			"device": {
+				"identifiers": [
+					"wmbusmeters_{id}"
+				],
+				"manufacturer": "INTEGRA METERING",
+				"model": "{driver}",
+				"name": "{name}",
+				"hw_version": "{id}"
+			},
+			"entity_category": "diagnostic",
+			"name": "timestamp",
+			"unique_id": "wmbusmeters_{id}_{attribute}",
+			"state_topic": "wmbusmeters/{name}",
+			"value_template": "{{ value_json.{attribute} }}",
+			"icon": "mdi:calendar-clock",
+			"enabled_by_default": false
+		}
+	}
+}


### PR DESCRIPTION
Works on my side, added only the most important ones. 


![grafik](https://github.com/user-attachments/assets/44fecf5b-919c-495e-9f75-8e30585cbcc0)

Sample telegram decrypted:
{
    "_":"telegram",
    "media":"water",
    "meter":"topaseskr",
    "name":"",
    "id":"333333",
    "access_counter":8,
    "battery_y":14.675182,
    "current_flow_m3h":0,
    "reverse_volume_year_period_m3":0,
    "temperature_c":19.1,
    "total_m3":48.363,
    "volume_month_period_m3":44.969,
    "volume_year_period_m3":30.429,
    "meter_month_period_end_datetime":"2025-03-31 23:59",
    "meter_year_period_end_date":"2024-12-31",
    "timestamp":"2025-04-19T12:15:08Z"
}