### PR TITLE
Add mqtt discovery file for hydrocalm4

### DIFF
--- a/wmbusmeters-ha-addon-edge/mqtt_discovery/hydrocalm4.json
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery/hydrocalm4.json
@@ -1,0 +1,169 @@
+{
+  "total_heating_kwh": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "(BMT) BMETERS",
+        "model": "{driver}",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "enabled_by_default": true,
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "state_class": "total",
+      "device_class": "energy",
+      "name": "total heating energy",
+      "state_topic": "wmbusmeters/{name}",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "unit_of_measurement": "kWh",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:home-lightning-bolt-outline"
+    }
+  },
+  "total_heating_m3": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "(BMT) BMETERS",
+        "model": "{driver}",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "enabled_by_default": true,
+      "state_class": "total",
+      "device_class": "water",
+      "name": "total heating volume",
+      "state_topic": "wmbusmeters/{name}",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "unit_of_measurement": "m³",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:water"
+    }
+  },
+  "total_cooling_kwh": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "(BMT) BMETERS",
+        "model": "{driver}",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "enabled_by_default": true,
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "state_class": "total",
+      "device_class": "energy",
+      "name": "total cooling energy",
+      "state_topic": "wmbusmeters/{name}",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "unit_of_measurement": "kWh",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:snowflake"
+    }
+  },
+  "total_cooling_m3": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "(BMT) BMETERS",
+        "model": "{driver}",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "enabled_by_default": true,
+      "state_class": "total",
+      "device_class": "water",
+      "name": "total cooling volume",
+      "state_topic": "wmbusmeters/{name}",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "unit_of_measurement": "m³",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:water"
+    }
+  },
+  "status": {
+    "component": "binary_sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "(BMT) BMETERS",
+        "model": "{driver}",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "enabled_by_default": false,
+      "entity_category": "diagnostic",
+      "device_class": "problem",
+      "name": "status",
+      "state_topic": "wmbusmeters/{name}",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "payload_on": "True",
+      "payload_off": "OK"
+    }
+  },
+  "timestamp": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "(BMT) BMETERS",
+        "model": "{driver}",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "timestamp",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:calendar-clock",
+      "enabled_by_default": false
+    }
+  },
+  "device_datetime": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "(BMT) BMETERS",
+        "model": "{driver}",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "device datetime",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:calendar-clock",
+      "enabled_by_default": false
+    }
+  },
+  "rssi_dbm": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": ["wmbusmeters_{id}"],
+        "manufacturer": "(BMT) BMETERS",
+        "model": "{driver}",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "enabled_by_default": false,
+      "entity_category": "diagnostic",
+      "device_class": "signal_strength",
+      "state_class": "measurement",
+      "name": "rssi",
+      "state_topic": "wmbusmeters/{name}",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "unit_of_measurement": "dBm",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:signal"
+    }
+  }
+}


### PR DESCRIPTION
I prepared hydrocalm4 mqtt discovery file. It is based on hydrocalm3 file and following data acquired from M-Bus Hydrocal M4 meter:
`{
    "_":"telegram",
    "media":"heat/cooling load",
    "meter":"hydrocalm4",
    "name":"",
    "id":"05154853",
    "device_datetime":"2025-05-09 13:15",
    "total_cooling_kwh":0.026924,
    "total_cooling_m3":0.039,
    "total_heating_kwh":915.967278,
    "total_heating_m3":55.592,
    "status":"OK",
    "timestamp":"2025-05-09T11:00:55Z"
}`