### PR TITLE
Update Log link in index.html

### DIFF
--- a/wmbusmeters-ha-addon-edge/rootfs/flask/templates/index.html
+++ b/wmbusmeters-ha-addon-edge/rootfs/flask/templates/index.html
@@ -21,7 +21,7 @@
           <a href="/" class="nav-link active" id="nav-home-tab" role="tab" aria-controls="nav-home" aria-selected="true">Home</a>
           <a href="/kem" class="nav-link" id="nav-kem-tab" role="tab" aria-controls="nav-kem" aria-selected="false">KEM processing</a>
           <a href="/drivers" class="nav-link" id="nav-driver-tab" role="tab" aria-controls="nav-driver" aria-selected="false">Drivers</a>
-          <a href="{{ request.host_url }}hassio/addon/{{ addon_slug }}/logs" class="nav-link" id="nav-logs-link" role="tab" aria-controls="nav-driver" aria-selected="false">Logs</a>
+          <a href="{{ request.host_url }}config/app/{{ addon_slug }}/logs" class="nav-link" id="nav-logs-link" role="tab" aria-controls="nav-driver" aria-selected="false">Logs</a>
           <script>
             document.getElementById('nav-logs-link').addEventListener('click', function (e) {
               e.preventDefault();


### PR DESCRIPTION
Following HA renaming of addon to app, the log location path has changed causing the "Log" link on the interface 404'ing

See
https://github.com/wmbusmeters/wmbusmeters/issues/1954