### PR TITLE
Add MQTT availability so HA flags meters unavailable when device is lost

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+* text=auto eol=lf
+
+*.sh text eol=lf
+*.py text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.conf text eol=lf
+
+# s6-overlay service scripts (no extension)
+rootfs/etc/services.d/**/run text eol=lf
+rootfs/etc/services.d/**/finish text eol=lf
+rootfs/etc/cont-init.d/** text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.ico binary

--- a/wmbusmeters-ha-addon-edge/DOCS.md
+++ b/wmbusmeters-ha-addon-edge/DOCS.md
@@ -55,6 +55,11 @@ See [project README for more information][docs]
 
 By default it is not enabled and leverages the _Moquitto broker_ addon details provided by supervisor. However, you can specify the custom mqtt broker connection details here.
 
+#### MQTT availability
+
+The addon publishes a retained availability state to `wmbusmeters/bridge/state` (`online` / `offline`). All entities created via MQTT auto-discovery reference this topic, so if the rtlwmbus device is unreachable (for example after a host reboot when the USB device is not re-attached) entities will appear as unavailable in Home Assistant rather than silently keeping their last value.
+
+State transitions are driven by wmbusmeters' own log output: `No wmbus device detected` (printed only when **all** configured listeners are down — so multi-dongle setups stay `online` while at least one device is alive) publishes `offline`; `Started config` publishes `online`. The wmbusmeters service `finish` hook also publishes `offline` on exit, and MQTT Last Will publishes `offline` if the addon dies uncleanly or loses its broker connection.
 
 ## Home Assistant integration
 
@@ -65,6 +70,9 @@ mqtt:
   sensor:
     - state_topic: "wmbusmeters/MainWater"
       json_attributes_topic: "wmbusmeters/MainWater"
+      availability_topic: "wmbusmeters/bridge/state"
+      payload_available: "online"
+      payload_not_available: "offline"
       unit_of_measurement: m³
       value_template: "{{ value_json.total_m3 }}"
       name: Water usage
@@ -73,10 +81,11 @@ mqtt:
       device_class: water
 ```
 
-_Please note: 
+_Please note:
 
 - `MainWater` is the water meter name used in `meters` configuration._
 - `device_class` is necessary to be adapt on your meters type (water, gas, etc.) [see here](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes)
+- The `availability_topic` lines are optional but recommended — they mirror what MQTT auto-discovery configures automatically, so your manual sensor will go `unavailable` when the rtlwmbus device is unreachable.
 
 ## Caveat
 

--- a/wmbusmeters-ha-addon-edge/Dockerfile
+++ b/wmbusmeters-ha-addon-edge/Dockerfile
@@ -63,6 +63,10 @@ ADD mqtt_discovery/ /mqtt_discovery/
 COPY mqtt_discovery.sh /
 RUN chmod a+x /mqtt_discovery.sh
 
+COPY availability.sh /
+COPY availability_filter.sh /
+RUN chmod a+x /availability.sh /availability_filter.sh
+
 COPY run.sh /
 RUN chmod a+x /run.sh
 
@@ -73,6 +77,8 @@ RUN chmod a+x /etc/services.d/flask/run
 RUN chmod a+x /etc/services.d/flask/finish
 RUN chmod a+x /etc/services.d/wmbusmeters/run
 RUN chmod a+x /etc/services.d/wmbusmeters/finish
+RUN chmod a+x /etc/services.d/availability/run
+RUN chmod a+x /etc/services.d/availability/finish
 RUN chmod a+x /etc/cont-init.d/nginx.sh
 
 ENTRYPOINT ["/init"]

--- a/wmbusmeters-ha-addon-edge/availability.sh
+++ b/wmbusmeters-ha-addon-edge/availability.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/with-contenv bashio
+# Hold a long-lived MQTT connection so the broker fires Last Will when the
+# addon dies uncleanly (crash, SIGKILL, network drop). State transitions
+# during normal operation are driven by /availability_filter.sh, which
+# inspects wmbusmeters' log output.
+
+ENV_FILE="/var/run/wmbusmeters/availability.env"
+
+while [[ ! -f "$ENV_FILE" ]]; do sleep 1; done
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+
+if [[ -z "$MQTT_HOST" || "$MQTT_HOST" == "none" ]]; then
+    bashio::log.info "Availability: MQTT not configured, LWT disabled."
+    exec sleep infinity
+fi
+
+ARGS=('-h' "$MQTT_HOST")
+[[ -n "$MQTT_PORT" ]] && ARGS+=('-p' "$MQTT_PORT")
+[[ -n "$MQTT_USER" ]] && ARGS+=('-u' "$MQTT_USER")
+[[ -n "$MQTT_PASSWORD" ]] && ARGS+=('-P' "$MQTT_PASSWORD")
+ARGS+=('--will-topic' "$AVAILABILITY_TOPIC"
+       '--will-payload' 'offline'
+       '--will-retain' '--will-qos' '1'
+       '-k' '30'
+       '-t' "$AVAILABILITY_TOPIC")
+
+bashio::log.info "Availability: holding LWT connection (topic=${AVAILABILITY_TOPIC})."
+
+while true; do
+    /usr/bin/mosquitto_sub "${ARGS[@]}" >/dev/null 2>&1
+    bashio::log.warning "Availability: LWT connection dropped, reconnecting in 5s."
+    sleep 5
+done

--- a/wmbusmeters-ha-addon-edge/availability_filter.sh
+++ b/wmbusmeters-ha-addon-edge/availability_filter.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/with-contenv bashio
+# Inspect wmbusmeters log output line by line, re-emit each line unchanged
+# (so the HA log view still shows everything), and publish online/offline
+# transitions to the MQTT availability topic when matching patterns appear.
+#
+# Patterns:
+#   "No wmbus device detected" -> wmbusmeters has zero active listeners
+#       (printed only when all configured devices are gone, so it stays correct
+#       in multi-dongle setups where losing one device is not yet a full
+#       outage). Other per-device messages like "Lost ... closing" and
+#       "[ALARM SpecifiedDeviceNotFound]" are intentionally NOT matched.
+#   "Started config ..." -> a listener became active. Safe to mark online
+#       even if other devices are still down; at least one is producing
+#       telegrams.
+
+ENV_FILE="/var/run/wmbusmeters/availability.env"
+[[ -f "$ENV_FILE" ]] && source "$ENV_FILE"
+
+PUB_ARGS=()
+if [[ -n "$MQTT_HOST" && "$MQTT_HOST" != "none" ]]; then
+    PUB_ARGS=('-h' "$MQTT_HOST")
+    [[ -n "$MQTT_PORT" ]] && PUB_ARGS+=('-p' "$MQTT_PORT")
+    [[ -n "$MQTT_USER" ]] && PUB_ARGS+=('-u' "$MQTT_USER")
+    [[ -n "$MQTT_PASSWORD" ]] && PUB_ARGS+=('-P' "$MQTT_PASSWORD")
+fi
+
+LAST_STATE=""
+
+publish() {
+    local state="$1"
+    [[ -z "$AVAILABILITY_TOPIC" ]] && return 0
+    [[ "${#PUB_ARGS[@]}" -eq 0 ]] && return 0
+    [[ "$state" == "$LAST_STATE" ]] && return 0
+    if /usr/bin/mosquitto_pub "${PUB_ARGS[@]}" -r -q 1 \
+            -t "$AVAILABILITY_TOPIC" -m "$state" 2>/dev/null; then
+        LAST_STATE="$state"
+        printf '[availability] -> %s\n' "$state" >&2
+    fi
+}
+
+while IFS= read -r line; do
+    printf '%s\n' "$line"
+    if [[ "$line" == *"Started config"* ]]; then
+        publish "online"
+    elif [[ "$line" == *"No wmbus device detected"* ]]; then
+        publish "offline"
+    fi
+done

--- a/wmbusmeters-ha-addon-edge/config.json
+++ b/wmbusmeters-ha-addon-edge/config.json
@@ -1,6 +1,6 @@
 {
     "name": "[edge] Wmbusmeters (W-MBus to MQTT)",
-    "version": "3.0.0-1",
+    "version": "3.0.1-1",
     "slug": "wmbusmeters-ha-addon-edge",
     "description": "Acquire utility meter readings using the wireless mbus protocol (WMBUS)",
     "arch": ["aarch64", "amd64"],

--- a/wmbusmeters-ha-addon-edge/mqtt_discovery.sh
+++ b/wmbusmeters-ha-addon-edge/mqtt_discovery.sh
@@ -2,12 +2,14 @@
 
 aryDiscTopic=()
 pub_args=()
-while getopts h:p:u:P:c:w: flag
+AVAILABILITY_TOPIC=""
+while getopts h:p:u:P:c:w:a: flag
 do
     case "${flag}" in
         h|p|u|P) pub_args+=("-${flag}" ${OPTARG});;
         c) CONFIG_PATH=${OPTARG};;
         w) CONFIG_DATA_PATH=${OPTARG};;
+        a) AVAILABILITY_TOPIC=${OPTARG};;
     esac
 done
 
@@ -61,10 +63,15 @@ if [ $CONFIG_MQTTDISCOVERY_ENABLED == "true" ]; then
                         filter=".${attribute}.discovery_payload"
                         payload=$(jq --raw-output -c -M $filter $file)
 
-                        for key in ${!aryKV[@]}; do                                                              
+                        for key in ${!aryKV[@]}; do
                             payload="${payload//\{$key\}/${aryKV[${key}]}}"
-                            #echo ${key} ${aryKV[${key}]}                                                             
+                            #echo ${key} ${aryKV[${key}]}
                         done
+                        if [[ -n "$AVAILABILITY_TOPIC" ]]; then
+                            payload=$(echo "$payload" | jq -c -M \
+                                --arg t "$AVAILABILITY_TOPIC" \
+                                '. + {availability_topic: $t, payload_available: "online", payload_not_available: "offline"}')
+                        fi
                         bashio::log.info "  Add/update topic: $topic"
                         #echo "  Payload: $payload"
                         aryDiscTopic+=($topic)

--- a/wmbusmeters-ha-addon-edge/rootfs/etc/services.d/availability/finish
+++ b/wmbusmeters-ha-addon-edge/rootfs/etc/services.d/availability/finish
@@ -1,0 +1,7 @@
+#!/usr/bin/env bashio
+# ==============================================================================
+# Restart availability monitor on exit. The script itself publishes "offline"
+# on SIGTERM/SIGINT, and MQTT LWT covers uncleanly-killed connections.
+# s6-overlay docs: https://github.com/just-containers/s6-overlay
+# ==============================================================================
+exit 0

--- a/wmbusmeters-ha-addon-edge/rootfs/etc/services.d/availability/run
+++ b/wmbusmeters-ha-addon-edge/rootfs/etc/services.d/availability/run
@@ -1,0 +1,7 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Start MQTT availability monitor
+# ==============================================================================
+
+bashio::log.info "Starting availability service."
+exec /availability.sh

--- a/wmbusmeters-ha-addon-edge/rootfs/etc/services.d/wmbusmeters/finish
+++ b/wmbusmeters-ha-addon-edge/rootfs/etc/services.d/wmbusmeters/finish
@@ -8,15 +8,31 @@ PROCESS_NAME="wmbusmeters"
 
 kill_process() {
     if pgrep "$PROCESS_NAME" > /dev/null; then
-        pkill "$PROCESS_NAME"       
+        pkill "$PROCESS_NAME"
     fi
 }
 
-# Check exit status and take action accordingly
+publish_offline() {
+    # wmbusmeters exiting means the device-reader is no longer running, so
+    # entities must be marked unavailable regardless of exit code. Best-effort.
+    local env_file="/var/run/wmbusmeters/availability.env"
+    [[ -f "$env_file" ]] || return 0
+    # shellcheck disable=SC1090
+    source "$env_file"
+    [[ -z "$MQTT_HOST" || "$MQTT_HOST" == "none" ]] && return 0
+    local args=('-h' "$MQTT_HOST")
+    [[ -n "$MQTT_PORT" ]] && args+=('-p' "$MQTT_PORT")
+    [[ -n "$MQTT_USER" ]] && args+=('-u' "$MQTT_USER")
+    [[ -n "$MQTT_PASSWORD" ]] && args+=('-P' "$MQTT_PASSWORD")
+    /usr/bin/mosquitto_pub "${args[@]}" -r -q 1 \
+        -t "$AVAILABILITY_TOPIC" -m "offline" 2>/dev/null || true
+}
+
+publish_offline
+
 if [[ "$1" -ne 0 ]] && [[ "$1" -ne 256 ]]; then
     bashio::log.warning "wmbusmeters exited with status $1."
     sleep 1
     kill_process
-    exit 0
 fi
 exit 0

--- a/wmbusmeters-ha-addon-edge/run.sh
+++ b/wmbusmeters-ha-addon-edge/run.sh
@@ -3,6 +3,10 @@
 CONFIG_PATH=/data/options_custom.json
 RESET_CONF=$(bashio::config 'reset_config')
 
+AVAILABILITY_TOPIC="wmbusmeters/bridge/state"
+AVAILABILITY_ENV="/var/run/wmbusmeters/availability.env"
+mkdir -p "$(dirname "$AVAILABILITY_ENV")"
+
 if [ ! -f ${CONFIG_PATH} ]
 then
     echo '{"data_path": "/config/wmbusmeters", "enable_mqtt_discovery": "false", "conf": {"loglevel": "normal", "device": "auto:t1", "donotprobe": "/dev/ttyAMA0", "logtelegrams": "false", "format": "json", "logfile": "/dev/stdout", "shell": "/wmbusmeters/mosquitto_pub.sh \"wmbusmeters/$METER_NAME\" \"$METER_JSON\""}, "meters": [], "mqtt": {}}' | jq . > ${CONFIG_PATH}
@@ -118,8 +122,26 @@ MESSAGE=\$2
 /usr/bin/mosquitto_pub ${pub_args_quoted[@]} -r -t "\$TOPIC" -m "\$MESSAGE"
 EOL
 
+    cat > "$AVAILABILITY_ENV" << EOL
+MQTT_HOST='${MQTT_HOST}'
+MQTT_PORT='${MQTT_PORT:-}'
+MQTT_USER='${MQTT_USER:-}'
+MQTT_PASSWORD='${MQTT_PASSWORD:-}'
+AVAILABILITY_TOPIC='${AVAILABILITY_TOPIC}'
+EOL
+
+    # Mark entities unavailable until wmbusmeters logs that the device is up.
+    /usr/bin/mosquitto_pub ${pub_args[@]} -r -q 1 \
+        -t "${AVAILABILITY_TOPIC}" -m "offline" || true
+
     # Running MQTT discovery
-    /mqtt_discovery.sh ${pub_args[@]} -c $CONFIG_PATH -w $CONFIG_DATA_PATH || true
+    /mqtt_discovery.sh ${pub_args[@]} -c $CONFIG_PATH -w $CONFIG_DATA_PATH \
+        -a "${AVAILABILITY_TOPIC}" || true
+else
+    cat > "$AVAILABILITY_ENV" << EOL
+MQTT_HOST='none'
+AVAILABILITY_TOPIC='${AVAILABILITY_TOPIC}'
+EOL
 fi
 
 chmod a+x /wmbusmeters/mosquitto_pub.sh
@@ -128,4 +150,7 @@ bashio::log.info "Running wmbusmeters ..."
 if pgrep wmbusmeters > /dev/null; then
     pkill wmbusmeters
 fi
-/wmbusmeters/wmbusmeters --useconfig=$CONFIG_DATA_PATH 
+# Pipe through the availability filter so device-lost / device-found log
+# lines are translated into MQTT availability state.
+set -o pipefail
+/wmbusmeters/wmbusmeters --useconfig=$CONFIG_DATA_PATH 2>&1 | /availability_filter.sh


### PR DESCRIPTION
When the rtlwmbus dongle is unreachable (e.g. USB not re-attached after a HAOS VM host reboot) meter entities would silently keep their last value. They now flip to "unavailable" in Home Assistant via a shared retained availability topic `wmbusmeters/bridge/state`.

State transitions are driven by three independent signals:

- `availability_filter.sh` pipes wmbusmeters stdout through a line-by-line matcher: `No wmbus device detected` -> offline (printed only when ALL configured listeners are down, so multi-dongle setups stay online while at least one device is alive); `Started config` -> online.
- `availability.sh` (new s6 service) holds a long-lived mosquitto_sub with Last Will armed, so the broker publishes offline if the addon dies uncleanly or loses its broker connection.
- The wmbusmeters s6 `finish` hook publishes offline unconditionally on process exit, covering wmbusmeters exiting before any log line is emitted and clean container shutdown.

`mqtt_discovery.sh` injects `availability_topic` / `payload_available` / `payload_not_available` into every entity discovery payload at publish time via jq, so the 38 driver JSONs do not need editing.

Also: add `.gitattributes` enforcing LF on shell scripts and s6 service files. Without it, a Windows checkout with `core.autocrlf=true` produces CRLF endings that break the s6-overlay shebangs (`exec: unable to exec bashio`) when the addon is built locally from that checkout.

Tested with Home Assistant 2026.6.4