### PR TITLE
Add mqtt_discovery/sanxing.json for the sanxing driver

### DIFF
--- a/wmbusmeters-ha-addon/mqtt_discovery/sanxing.json
+++ b/wmbusmeters-ha-addon/mqtt_discovery/sanxing.json
@@ -1,0 +1,379 @@
+{
+  "total_energy_consumption_kwh": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "total energy consumption",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} or (value_json.total_energy_consumption_tariff_1_kwh + value_json.total_energy_consumption_tariff_2_kwh + value_json.total_energy_consumption_tariff_3_kwh) }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:transmission-tower-import",
+      "unit_of_measurement": "kWh",
+      "state_class": "total_increasing",
+      "device_class": "energy",
+      "enabled_by_default": true
+    }
+  },
+  "total_energy_consumption_tariff_1_kwh": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "total energy consumption for tariff 1",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:transmission-tower-import",
+      "unit_of_measurement": "kWh",
+      "state_class": "total_increasing",
+      "device_class": "energy",
+      "enabled_by_default": false
+    }
+  },
+  "total_energy_consumption_tariff_2_kwh": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "total energy consumption for tariff 2",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:transmission-tower-import",
+      "unit_of_measurement": "kWh",
+      "state_class": "total_increasing",
+      "device_class": "energy",
+      "enabled_by_default": false
+    }
+  },
+  "total_energy_consumption_tariff_3_kwh": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "total energy consumption for tariff 3",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:transmission-tower-import",
+      "unit_of_measurement": "kWh",
+      "state_class": "total_increasing",
+      "device_class": "energy",
+      "enabled_by_default": false
+    }
+  },
+  "total_energy_production_kwh": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "total energy production",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} or (value_json.total_energy_production_tariff_1_kwh + value_json.total_energy_production_tariff_2_kwh + value_json.total_energy_production_tariff_3_kwh) }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:transmission-tower-export",
+      "unit_of_measurement": "kWh",
+      "state_class": "total_increasing",
+      "device_class": "energy",
+      "enabled_by_default": true
+    }
+  },
+  "total_energy_production_tariff_1_kwh": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "total energy production for tariff 1",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:transmission-tower-export",
+      "unit_of_measurement": "kWh",
+      "state_class": "total_increasing",
+      "device_class": "energy",
+      "enabled_by_default": false
+    }
+  },
+  "total_energy_production_tariff_2_kwh": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "total energy production for tariff 2",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:transmission-tower-export",
+      "unit_of_measurement": "kWh",
+      "state_class": "total_increasing",
+      "device_class": "energy",
+      "enabled_by_default": false
+    }
+  },
+  "total_energy_production_tariff_3_kwh": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "total energy production for tariff 3",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:transmission-tower-export",
+      "unit_of_measurement": "kWh",
+      "state_class": "total_increasing",
+      "device_class": "energy",
+      "enabled_by_default": false
+    }
+  },
+  "current_power_consumption_kw": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "current power consumption",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:counter",
+      "unit_of_measurement": "kW",
+      "state_class": "measurement",
+      "device_class": "power",
+      "enabled_by_default": true
+    }
+  },
+  "current_power_production_kw": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "current power production",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "icon": "mdi:counter",
+      "unit_of_measurement": "kW",
+      "state_class": "measurement",
+      "device_class": "power",
+      "enabled_by_default": true
+    }
+  },
+  "voltage_at_phase_1_v": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "voltage at phase 1",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "unit_of_measurement": "V",
+      "state_class": "measurement",
+      "device_class": "voltage",
+      "enabled_by_default": true
+    }
+  },
+  "voltage_at_phase_2_v": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "voltage at phase 2",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "unit_of_measurement": "V",
+      "state_class": "measurement",
+      "device_class": "voltage",
+      "enabled_by_default": false
+    }
+  },
+  "voltage_at_phase_3_v": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "name": "voltage at phase 3",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "json_attributes_topic": "wmbusmeters/{name}",
+      "unit_of_measurement": "V",
+      "state_class": "measurement",
+      "device_class": "voltage",
+      "enabled_by_default": false
+    }
+  },
+  "timestamp": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "timestamp",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:calendar-clock",
+      "device_class": "timestamp",
+      "enabled_by_default": false
+    }
+  },
+  "device_date_time": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "Device date and time",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:calendar-clock",
+      "device_class": "timestamp",
+      "enabled_by_default": false
+    }
+  },
+  "rssi_dbm": {
+    "component": "sensor",
+    "discovery_payload": {
+      "device": {
+        "identifiers": [
+          "wmbusmeters_{id}"
+        ],
+        "manufacturer": "Sanxing",
+        "model": "Electricity meter Sanxing S34U28 (driver: {driver})",
+        "name": "{name}",
+        "hw_version": "{id}"
+      },
+      "entity_category": "diagnostic",
+      "name": "rssi",
+      "unique_id": "wmbusmeters_{id}_{attribute}",
+      "state_topic": "wmbusmeters/{name}",
+      "value_template": "{{ value_json.{attribute} }}",
+      "icon": "mdi:signal",
+      "unit_of_measurement": "dBm",
+      "device_class": "signal_strength",
+      "state_class": "measurement",
+      "enabled_by_default": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- The `sanxing` driver (Sanxing S34U28, KPL mfct code — wmbusmeters/wmbusmeters#2043, currently open) has no HA MQTT discovery template in `mqtt_discovery/`.
- Without one, `mqtt_discovery.sh` logs `File ... not found` and silently skips publishing discovery configs for `sanxing` meters. wmbusmeters still publishes the meter data over MQTT fine, but Home Assistant never learns the topic exists, so no entities get created — the data effectively vanishes from HA's point of view.
- `sanxing.xmq` intentionally mirrors the `amiplus`/Apator field set byte-for-byte (same field names, same units), so this file reuses `amiplus.json`'s field/unit keys and `value_template`s as-is, with `manufacturer`/`model` swapped to Sanxing/S34U28.

## Note on `make generate_ha_discovery`
I initially tried generating this file the "proper" way via `cd drivers && make generate_ha_discovery` in wmbusmeters, but that currently produces broken keys for this driver — e.g. `current_power_consumption_` instead of `current_power_consumption_kw` — because `to-ha-discovery.xslq`'s unit map (`my:tounit`) only has entries for `Volume`/`Flow` quantities. Every other quantity (Energy, Power, Voltage, PointInTime — i.e. everything `sanxing.xmq` uses) resolves to an empty unit suffix, so the generated keys don't match what wmbusmeters actually publishes in the JSON payload.

That looks like a separate, pre-existing bug in the generator (not something new here — `mqtt_discovery/*.json` in this repo is already hand-maintained/updated rather than regenerated, per the Dockerfile's `generate_ha_discovery` step being commented out and the amiplus.json edit history). Not attempting to fix the generator in this PR; flagging it here in case it's useful context for whoever picks it up.

## Depends on
wmbusmeters/wmbusmeters#2043 (the `sanxing` driver itself) landing upstream first. Opening as **draft** until that merges.

## Test plan
- [x] Verified against my own Sanxing S34U28 meter on a local build of this addon (`bryszard/wmbusmeters-ha-addon@kpl-fix`): after dropping this file into the addon's discovery folder and restarting, `mqtt_discovery.sh` published the correct `homeassistant/sensor/wmbusmeters/<id>_<field>_<unit>/config` topics and entities appeared correctly in Home Assistant with `manufacturer: Sanxing`.
- [ ] Re-verify once wmbusmeters/wmbusmeters#2043 merges and this can run against the official image.